### PR TITLE
Add agent handbook and testing guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Agent Handbook
+
+## Directory Structure
+- `app.py` - Dash application entry point
+- `src/` - Application modules and utilities
+- `tests/` - Unit and integration tests
+- `notebooks/` - Example analysis notebooks
+- `Dockerfile.jupyter` - Container image for Jupyter environment
+
+## Coding Standards
+- Use **Python 3.9**.
+- Follow [PEP8](https://peps.python.org/pep-0008/) style guidelines.
+- Prefer type hints and dataclasses for new code.
+- Keep functions small with clear docstrings.
+
+## Build & Test Commands
+- Install dependencies:
+  ```bash
+  pip install -r requirements.txt
+  pip install pytest pytest-cov openai
+  ```
+- Run tests:
+  ```bash
+  pytest
+  ```
+- Launch the dashboard locally:
+  ```bash
+  python app.py
+  ```
+
+## Prompt Patterns
+- Include file paths and function names in prompts when requesting changes.
+- Break large tasks into sequenced steps.
+
+## Workflow
+1. Create a clean Python 3.9 environment or use `Dockerfile.jupyter`.
+2. Install dependencies and dev tools as above.
+3. Run the test suite to verify the setup.
+4. Start the app with `python app.py` or via Docker.
+5. Commit code with concise messages describing the change.
+

--- a/README.md
+++ b/README.md
@@ -159,6 +159,13 @@ For quick exploration and analysis:
 
 4. Open your browser and navigate to: `http://127.0.0.1:8050`
 
+### Testing
+Install development dependencies and run the unit tests to verify your setup:
+```bash
+pip install pytest pytest-cov openai
+pytest
+```
+
 ### Production Deployment
 1. Set environment variables for production
 2. Use Gunicorn to run the application:


### PR DESCRIPTION
## Summary
- document workflow in new `AGENTS.md`
- add testing instructions to README

## Testing
- `pytest -q tests/test_ml_utils.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6844c166af7083309efa136c7d35ed5f