### PR TITLE
Add docker-compose to run tests and start dashboard

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  dashboard:
+    build: .
+    ports:
+      - '8050:8050'
+    command: >
+      sh -c "pytest --maxfail=1 --disable-warnings -q &&
+             python app.py"


### PR DESCRIPTION
## Summary
- define dashboard service running tests before launching the app

## Testing
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6844c420c82c83309b3eced60eeb4ec9