### PR TITLE
Add verify script

### DIFF
--- a/verify.sh
+++ b/verify.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+pip install -r requirements.txt
+pytest --maxfail=1 --disable-warnings -q
+docker-compose build --quiet
+docker-compose up --abort-on-container-exit


### PR DESCRIPTION
## Summary
- add verification script `verify.sh` that installs dependencies, runs tests, and builds Docker images

## Testing
- `pip install pytest pytest-cov openai`
- `pytest -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6844c43f464c8330ac4d94a3cbf36074